### PR TITLE
fix: experiences list border could only support 2 items

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -28,29 +28,17 @@ import Layout from "../layouts/main.astro";
     </h2>
     <div class="px-5 py-10">
       {
-        experiences.map((experience, loop) => {
+        experiences.map((experience) => {
           return (
-            <>
-              {loop == 0 || loop == 1 ? (
-                <div class="pb-10 border-l border-gray-200 dark:border-neutral-700">
-                  <AboutExperience
-                    dates={experience.dates}
-                    role={experience.role}
-                    company={experience.company}
-                    description={experience.description}
-                    logo={experience.logo}
-                  />
-                </div>
-              ) : (
-                <AboutExperience
-                  dates={experience.dates}
-                  role={experience.role}
-                  company={experience.company}
-                  description={experience.description}
-                  logo={experience.logo}
-                />
-              )}
-            </>
+            <div class="pb-10 border-l border-gray-200 last:border-l-0 dark:border-neutral-700">
+              <AboutExperience
+                dates={experience.dates}
+                role={experience.role}
+                company={experience.company}
+                description={experience.description}
+                logo={experience.logo}
+              />
+            </div>
           )
         })
       }


### PR DESCRIPTION
Instead of basing the last border on the current index, we can just use Tailwind's `last:` scope to make it support any number of items.