### PR TITLE
fix: Sort posts by date with latest appearing first

### DIFF
--- a/src/components/posts-loop.astro
+++ b/src/components/posts-loop.astro
@@ -4,11 +4,23 @@ const allPosts = await getCollection("post");
 
 const { count } = Astro.props;
 
-const postsLoop = allPosts.slice(0, count).map((post) => {
-	return {
-		...(post.data || {}),
-		link: `/post/${post.slug}`,
-	};
+function parseDate(dateStr) {
+  const [month, day, year] = dateStr.split(" ");
+  return new Date(`${month} ${parseInt(day)}, ${year}`);
+}
+
+const sortedPosts = allPosts
+  .map((post) => ({
+    ...post,
+    date: parseDate(post.data.dateFormatted),
+  }))
+  .sort((a, b) => b.date.getTime() - a.date.getTime());
+
+const postsLoop = sortedPosts.slice(0, count).map((post) => {
+  return {
+    ...(post.data || {}),
+    link: `/post/${post.slug}`,
+  };
 });
 ---
 


### PR DESCRIPTION
I would like to propose this change since currently the blog posts are appearing in alphabetical sort order of the .md files. I think it makes more sense to sort them based on the dateformatted value and make life easier for us instead of having to organize the files by a naming strategy.